### PR TITLE
Loosen semver restriction on shared workflows

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.1
+    uses: folio-org/.github/.github/workflows/ui.yml@v1
     secrets: inherit
     with:
       jest-enabled: true

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   ui:
     uses: folio-org/.github/.github/workflows/ui.yml@v1
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## 1.0.0 IN PROGRESS
 
 * Copied and pruned from folio-org/stripes-cli
+* Loosen semver restriction on shared workflows
 


### PR DESCRIPTION
Loosen the semver restriction on shared workflows, allowing the repository to pick up new minor-versions automatically.