### PR TITLE
omit aliasCount

### DIFF
--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -35,7 +35,7 @@ function statusCommand(argv) {
     console.log(`  ${pluginNames}`);
   }
 
-  if (!context.isLocalCoreAvailable || aliasCount) {
+  if (!context.isLocalCoreAvailable) {
     console.log('\nWARNING: The current configuration may not be suitable for production builds.');
   }
 


### PR DESCRIPTION
Aliases are deprecated but I missed this one reference to `aliasCount` when pruning the codebase.