### PR TITLE
omit .npmrc which never should have been committed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@folio:registry = https://repository.folio.org/repository/npm-folioci/


### PR DESCRIPTION
Omit `.npmrc` file which was only committed on accident.