### PR TITLE
STCLI-285 - decouple from yarn classic.

### DIFF
--- a/lib/cli/global-dirs.js
+++ b/lib/cli/global-dirs.js
@@ -10,7 +10,7 @@ function isYarnVersion(version) {
     logger.log('Yarn version', yarnVersion);
     return semver.satisfies(yarnVersion, version);
   } catch (err) {
-    logger.error('Unable to determine Yarn version.', err);
+    logger.log('Unable to determine Yarn version.', err && err.message ? err.message : err);
     return false;
   }
 }

--- a/lib/cli/global-dirs.js
+++ b/lib/cli/global-dirs.js
@@ -10,7 +10,7 @@ function isYarnVersion(version) {
     logger.log('Yarn version', yarnVersion);
     return semver.satisfies(yarnVersion, version);
   } catch (err) {
-    logger.log('Unable to determine Yarn version.', err && err.message ? err.message : err);
+    logger.log('Unable to determine Yarn version.', err?.message ? err.message : err);
     return false;
   }
 }

--- a/lib/cli/stripes-core.js
+++ b/lib/cli/stripes-core.js
@@ -58,9 +58,9 @@ module.exports = class StripesCore {
   }
 
   getCoreModulePath(moduleId) {
-    const coreModulePath = (this.corePath === this.coreAlias)
-      ? path.join(this.corePath, moduleId)
-      : resolveFrom(this.corePath, `@folio/stripes-webpack/${moduleId}`);
+    const coreModulePath = (this.corePath.includes('node_modules'))
+      ? resolveFrom(this.corePath, `@folio/stripes-webpack/${moduleId}`)
+      : path.join(this.corePath, moduleId);
     return coreModulePath;
   }
 

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -1,0 +1,76 @@
+const childProcess = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+function hasCommand(cmd) {
+  try {
+    const v = childProcess.execSync(`${cmd} --version`, { encoding: 'utf8' }).trim();
+    // simple check that command exists and returns something
+    return !!v;
+  } catch (e) {
+    return false;
+  }
+}
+
+function detect(projectDir) {
+  // Env override
+  const env = process.env.STRIPES_PKG_MANAGER;
+  if (env) return env;
+
+  // Prefer pnpm if a lockfile exists nearby
+  try {
+    const pnpmLock = path.join(projectDir || process.cwd(), 'pnpm-lock.yaml');
+    if (fs.existsSync(pnpmLock) && hasCommand('pnpm')) return 'pnpm';
+  } catch (e) {
+    // ignore
+  }
+
+  if (hasCommand('pnpm')) return 'pnpm';
+  if (hasCommand('yarn')) return 'yarn';
+  if (hasCommand('npm')) return 'npm';
+
+  // default to npm if nothing else
+  return 'npm';
+}
+
+function execCmd(cmd, args, options) {
+  return new Promise((resolve, reject) => {
+    const full = `${cmd} ${args.join(' ')}`.trim();
+    const p = childProcess.exec(full, options, (error) => {
+      if (error) return reject(error);
+      resolve({ isInstalled: true, appDir: options && options.cwd });
+    });
+    if (p && p.stdout) p.stdout.on('data', d => console.log(`  ${d.toString().trim()}`));
+    if (p && p.stderr) p.stderr.on('data', d => console.error(`  ${d.toString().trim()}`));
+  });
+}
+
+function install(projectDir) {
+  const pm = detect(projectDir);
+  console.log(`Using package manager: ${pm}`);
+  if (pm === 'pnpm') return execCmd('pnpm', ['install', '--frozen-lockfile'], { cwd: projectDir });
+  if (pm === 'yarn') return execCmd('yarn', [], { cwd: projectDir });
+  return execCmd('npm', ['install'], { cwd: projectDir });
+}
+
+function add(projectDir, packageName, isDev) {
+  const pm = detect(projectDir);
+  console.log(`Using package manager: ${pm}`);
+  const pkgs = [].concat(packageName).join(' ');
+  if (pm === 'pnpm') {
+    const flag = isDev ? ['-D'] : [];
+    return execCmd('pnpm', ['add'].concat(flag).concat([pkgs]), { cwd: projectDir });
+  }
+  if (pm === 'yarn') {
+    const flag = isDev ? '--dev' : '';
+    return execCmd('yarn', ['add', flag, pkgs].filter(Boolean), { cwd: projectDir });
+  }
+  const flag = isDev ? ['--save-dev'] : ['--save'];
+  return execCmd('npm', ['install'].concat(flag).concat([pkgs]), { cwd: projectDir });
+}
+
+module.exports = {
+  detect,
+  install,
+  add,
+};

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -1,6 +1,6 @@
-const childProcess = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const childProcess = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
 
 function hasCommand(cmd) {
   try {
@@ -8,7 +8,7 @@ function hasCommand(cmd) {
     // simple check that command exists and returns something
     return !!v;
   } catch (e) {
-    return false;
+    throw new Error(`There was an error in stripes-cli initialization: Command not found - ${cmd}`, { cause: e });
   }
 }
 
@@ -22,7 +22,7 @@ function detect(projectDir) {
     const pnpmLock = path.join(projectDir || process.cwd(), 'pnpm-lock.yaml');
     if (fs.existsSync(pnpmLock) && hasCommand('pnpm')) return 'pnpm';
   } catch (e) {
-    // ignore
+    throw new Error('There was an error in stripes-cli initialization: Unable to detect package manager.', { cause: e });
   }
 
   if (hasCommand('pnpm')) return 'pnpm';
@@ -38,10 +38,11 @@ function execCmd(cmd, args, options) {
     const full = `${cmd} ${args.join(' ')}`.trim();
     const p = childProcess.exec(full, options, (error) => {
       if (error) return reject(error);
-      resolve({ isInstalled: true, appDir: options && options.cwd });
+      resolve({ isInstalled: true, appDir: options?.cwd });
+      return undefined;
     });
-    if (p && p.stdout) p.stdout.on('data', d => console.log(`  ${d.toString().trim()}`));
-    if (p && p.stderr) p.stderr.on('data', d => console.error(`  ${d.toString().trim()}`));
+    if (p?.stdout) p.stdout.on('data', d => console.log(`  ${d.toString().trim()}`));
+    if (p?.stderr) p.stderr.on('data', d => console.error(`  ${d.toString().trim()}`));
   });
 }
 
@@ -56,7 +57,7 @@ function install(projectDir) {
 function add(projectDir, packageName, isDev) {
   const pm = detect(projectDir);
   console.log(`Using package manager: ${pm}`);
-  const pkgs = [].concat(packageName).join(' ');
+  const pkgs = packageName.flat().join(' ');
   if (pm === 'pnpm') {
     const flag = isDev ? ['-D'] : [];
     return execCmd('pnpm', ['add'].concat(flag).concat([pkgs]), { cwd: projectDir });

--- a/lib/yarn.js
+++ b/lib/yarn.js
@@ -1,69 +1,22 @@
-const childProcess = require('child_process');
-
-function runYarn(options) {
-  return new Promise((resolve, reject) => {
-    const installProcess = childProcess.exec('yarn', options, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve({ isInstalled: true, appDir: options.cwd });
-    });
-    installProcess.stdout.on('data', data => console.log(`  ${data.trim()}`));
-  });
-}
-
-function yarnAdd(packageName, isDevDep, options) {
-  const pkgs = [].concat(packageName).join(' ');
-  const flag = isDevDep ? '--dev' : '';
-
-  return new Promise((resolve, reject) => {
-    const installProcess = childProcess.exec(`yarn add ${flag} ${pkgs}`, options, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve({ isInstalled: true, appDir: options.cwd });
-    });
-    installProcess.stdout.on('data', data => console.log(`  ${data.trim()}`));
-  });
-}
-
-// Above method does not capture full yarn output, but is a lot quieter
-// TODO: Offer option to toggle between the two
-
-// function runYarn(options) {
-//   options.stdio = 'inherit';
-//   return new Promise((resolve, reject) => {
-//     childProcess.spawn('yarn', [], options)
-//       .on('exit', (error) => {
-//         if (error) {
-//           reject(error);
-//         }
-//         resolve({ isInstalled: true, appDir: options.cwd });
-//       });
-//   });
-// }
+// Backwards-compatible shim. Use package-manager abstraction which prefers pnpm when available.
+const packageManager = require('./package-manager');
 
 function install(projectDir) {
   console.log(` Directory "${projectDir}"`);
-  return runYarn({ cwd: projectDir })
+  return packageManager.install(projectDir)
     .catch((err) => {
-      console.error('Something went wrong while attempting to use Yarn.');
+      console.error('Something went wrong while attempting to run package manager install.');
       console.info(err);
     });
 }
 
 function add(projectDir, packageName, isDev) {
   console.log(` Directory "${projectDir}"`);
-  return yarnAdd(packageName, isDev, { cwd: projectDir })
+  return packageManager.add(projectDir, packageName, isDev)
     .catch((err) => {
-      console.error('Something went wrong while attempting to use Yarn.');
+      console.error('Something went wrong while attempting to add package via package manager.');
       console.info(err);
     });
 }
 
-module.exports = {
-  add,
-  install,
-};
+module.exports = { add, install };


### PR DESCRIPTION
This PR is the start of a journey to migrate away from yarn v 1.22.22 aka yarn 'classic'.
We've got a lot of packages, a lot of tools served by `stripes-build` and `stripes-cli` aka 'the tooling' - Ideally we can make the transition from one package manager to another as smooth as possible.

The tooling checks for a global yarn install with global package directories (begrudging, and hopefully we don't find ourselves doing this with whichever package manager is next.) This creates a contextual boolean within the context of each tool process and logic carries forward. It's been a while since we switched from `npm` to `yarn` in tool functionality has just become accustomed to yarn being there.

The approach in this PR was assisted with AI for all those package-manager commands and the logic for checking. It creates a generic `package-manager.js` file that covers checking whether `yarn`, `pnpm` or `npm` is the package-manager we have access to. It converts the pre-existing `yarn.js` to a shim that just uses the `package-manager.js` commands. `package-manager` could be imported/used here forward.

Additionally, this PR updates the resolution of the `core` module during the build process. This is infamous code, leftover from lifting build logic from `stripes-core` since the variables retained `core` in the name, but the important ones reference `stripes-webpack`. I haven't modified those variables just yet - just the way it finds the variable if it's determined that it is within the `node_modules` directory vs a neighboring package within a workspace.

The logic here does prefer `pnpm` if it's available by checking whether the `pnpm-lock.yaml` file exists. `npm` is.. well.. always available, so it's the fallback.
