### PR TITLE
STRIPES-1029 supply `mod descriptor --single`, populate metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Supply Personal Data Disclosure form. Refs STRIPES-980.
+* Supply `mod descriptor --single`. Refs STRIPES-1029.
 
 ## 1.1.0 IN PROGRESS
 

--- a/lib/cli/generate-module-descriptor.js
+++ b/lib/cli/generate-module-descriptor.js
@@ -1,5 +1,4 @@
-// Logic borrowed from stripes-core's package2md.js excluding file load and console output
-// $ node ../stripes-core/util/package2md.js package.json > MD.json
+const { omit } = require('lodash');
 module.exports = function generateModuleDescriptor(packageJson, isStrict) {
   const stripes = packageJson.stripes || {};
   const moduleDescriptor = {
@@ -12,6 +11,9 @@ module.exports = function generateModuleDescriptor(packageJson, isStrict) {
     moduleDescriptor.requires = Object.keys(interfaces).map(key => ({ id: key, version: interfaces[key] }));
     const optional = stripes.optionalOkapiInterfaces || [];
     moduleDescriptor.optional = Object.keys(optional).map(key => ({ id: key, version: optional[key] }));
+    moduleDescriptor.metadata = {
+      stripes: omit(stripes, ['okapiInterfaces', 'optionalOkapiInterfaces', 'permissionSets']),
+    };
   }
   return moduleDescriptor;
 };

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -14,7 +14,8 @@ function moduleDescriptorCommand(argv) {
     DescriptorService.writeModuleDescriptorsToDirectory(descriptors, argv.output);
     console.log(`${descriptors.length} module descriptors written to ${argv.output}`);
   } else if (argv.full) {
-    console.log(JSON.stringify(descriptors, null, 2));
+    const output = argv.single && descriptors.length === 1 ? descriptors[0] : descriptors;
+    console.log(JSON.stringify(output, null, 2));
   } else {
     descriptors.forEach(descriptor => console.log(descriptor.id));
   }
@@ -37,6 +38,11 @@ module.exports = {
       })
       .option('strict', {
         describe: 'Include required interface dependencies',
+        type: 'boolean',
+        default: false,
+      })
+      .option('single', {
+        describe: 'Full JSON descriptor for a single module in the current working directory',
         type: 'boolean',
         default: false,
       })


### PR DESCRIPTION
Port features added to stripes-cli in [STCLI-274](https://folio-org.atlassian.net/browse/STCLI-274):
* `mod descriptor` should populate `metadata`
* `mod descriptor` should support `--single` flag

Refs [STRIPES-1029](https://folio-org.atlassian.net/browse/STRIPES-1029)